### PR TITLE
Merge feature/kotlin-migration into main

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -26,12 +26,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(21)
     }
 }
 
@@ -55,7 +55,7 @@ dependencies {
     // Dependency Injection
     // https://developer.android.com/training/dependency-injection/hilt-android
     implementation "com.google.dagger:hilt-android:$daggerHiltVersion"
-    kapt "com.google.dagger:hilt-android-compiler:$daggerHiltVersion"
+    ksp "com.google.dagger:hilt-compiler:$daggerHiltVersion"
     kapt "androidx.hilt:hilt-compiler:$hiltVersion"
 
     // Retrofit

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -25,13 +25,13 @@ android {
         }
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(21)
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     buildFeatures {
@@ -61,7 +61,7 @@ dependencies {
     // Dependency Injection
     // https://developer.android.com/training/dependency-injection/hilt-android
     implementation "com.google.dagger:hilt-android:$daggerHiltVersion"
-    kapt "com.google.dagger:hilt-android-compiler:$daggerHiltVersion"
+    ksp "com.google.dagger:hilt-compiler:$daggerHiltVersion"
     kapt "androidx.hilt:hilt-compiler:$hiltVersion"
 
     // Activity

--- a/base/src/main/java/com/applakazam/androidmvvmtemplate/base/viewmodel/BaseNetworkViewModel.kt
+++ b/base/src/main/java/com/applakazam/androidmvvmtemplate/base/viewmodel/BaseNetworkViewModel.kt
@@ -18,7 +18,7 @@ open class BaseNetworkViewModel @Inject constructor() : BaseViewModel() {
     @Inject
     lateinit var errorTranslator: BaseErrorTranslator
 
-    private val _displayBlockingErrorLiveData = MutableLiveData<Event<@StringRes Int>>()
+    private val _displayBlockingErrorLiveData = MutableLiveData<Event<Int>>()
     val displayBlockingErrorLiveData: LiveData<Event<Int>>
         get() = _displayBlockingErrorLiveData
 
@@ -31,7 +31,7 @@ open class BaseNetworkViewModel @Inject constructor() : BaseViewModel() {
         return errorTranslator.translateError(exception)
     }
 
-    private fun displayRequestError(@StringRes messageRes: Int) {
+    private fun displayRequestError(messageRes: Int) {
         _displayBlockingErrorLiveData.value = Event(messageRes)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.2.1' apply false
-    id 'com.android.library' version '8.2.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
-    id 'com.google.devtools.ksp' version '1.9.22-1.0.17' apply false
-    id 'com.google.dagger.hilt.android' version '2.46' apply false
-    id 'androidx.navigation.safeargs' version '2.5.3' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version "1.9.22" apply false
+    id 'com.android.application' version '8.11.1' apply false
+    id 'com.android.library' version '8.11.1' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
+    id 'com.google.devtools.ksp' version '2.2.0-2.0.2' apply false
+    id 'com.google.dagger.hilt.android' version '2.56.2' apply false
+    id 'androidx.navigation.safeargs' version '2.9.3' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version "2.2.0" apply false
 }

--- a/contacts/build.gradle
+++ b/contacts/build.gradle
@@ -26,12 +26,12 @@ android {
     }
     
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(21)
     }
 
     buildFeatures {
@@ -64,7 +64,7 @@ dependencies {
     // Dependency Injection
     // https://developer.android.com/training/dependency-injection/hilt-android
     implementation "com.google.dagger:hilt-android:$daggerHiltVersion"
-    kapt "com.google.dagger:hilt-android-compiler:$daggerHiltVersion"
+    ksp "com.google.dagger:hilt-compiler:$daggerHiltVersion"
     kapt "androidx.hilt:hilt-compiler:$hiltVersion"
 
     // Fragment

--- a/extensions/build.gradle
+++ b/extensions/build.gradle
@@ -21,11 +21,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(21)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # Dependencies versions
-kotlinVersion = 1.12.0
+kotlinVersion = 1.16.0
 appCompatVersion = 1.7.1
 constraintLayoutVersion = 2.1.4
 materialVersion = 1.12.0
@@ -36,7 +36,7 @@ viewModelVersion = 2.9.2
 liveDataVersion = 2.9.2
 coroutinesVersion = 1.7.1
 hiltVersion = 1.1.0
-daggerHiltVersion = 2.46
+daggerHiltVersion = 2.56.2
 kotlinSerializationVersion = 1.6.0
 # next Retrofit update depends on Kotlin 2.2.0
 retrofitVersion = 2.9.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jan 17 19:42:02 EET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -28,13 +28,13 @@ android {
         }
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(21)
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     buildFeatures {
@@ -67,7 +67,7 @@ dependencies {
     // Dependency Injection
     // https://developer.android.com/training/dependency-injection/hilt-android
     implementation "com.google.dagger:hilt-android:$daggerHiltVersion"
-    kapt "com.google.dagger:hilt-android-compiler:$daggerHiltVersion"
+    ksp "com.google.dagger:hilt-compiler:$daggerHiltVersion"
     kapt "androidx.hilt:hilt-compiler:$hiltVersion"
 
     // Live Data

--- a/navigation/build.gradle
+++ b/navigation/build.gradle
@@ -22,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(21)
     }
 }
 


### PR DESCRIPTION
- bumped Hilt to 2.56.2
- bumped Gradle to 8.14.3
- bumped AGP to 8.11.1
- bumped Kotlin to 2.2.0
- bumped KSP to 2.2.0
- bumped SafeArgs to 2.9.3
- bumped Java compatibility to Java 21
- removed deprecated annotations